### PR TITLE
Make URL compatible with Douban

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ npm start
 
 #### 请求地址  
 
-`{HOST}/book?id=<id>`  
-`{HOST}/book?isbn=<isbn>`
+`{HOST}/subject/<id>`  
+`{HOST}/isbn/<isbn>`
 
 #### 请求方式  
 
@@ -146,8 +146,8 @@ npm start
 
 #### 返回示例
 
-`{HOST}/book?id=27012117`: [DEMO](https://acdzh-douban-book-api.herokuapp.com/book?id=27012117)  
-`{HOST}/book?isbn=9787208140400`: [DEMO](https://acdzh-douban-book-api.herokuapp.com/book?isbn=9787208140400)
+`{HOST}/subject/27012117`: [DEMO](https://acdzh-douban-book-api.herokuapp.com/subject/27012117)  
+`{HOST}/isbn/9787208140400`: [DEMO](https://acdzh-douban-book-api.herokuapp.com/isbn/9787208140400)
 
 ```json
 {

--- a/calibre/__init__.py
+++ b/calibre/__init__.py
@@ -102,12 +102,12 @@ class DoubanBookSearcher:
     return None
 
   def get_book_by_douban_id(self, douban_id, log):
-    url = urljoin(self.api_host, f'/book?id=/{douban_id}')
+    url = urljoin(self.api_host, f'/subject/{douban_id}')
     data = self.request(url, log)
     return data
 
   def get_book_by_isbn(self, isbn, log):
-    url = urljoin(self.api_host, f'/book?isbn=/{isbn}')
+    url = urljoin(self.api_host, f'/isbn/{isbn}')
     data = self.request(url, log)
     return data
 

--- a/src/router.js
+++ b/src/router.js
@@ -42,31 +42,41 @@ router.get('/search', async (ctx) => {
   }
 });
 
-router.get('/book', async (ctx) => {
-  const { id = '', isbn = '', update } = ctx.query;
-  if (id === '' && isbn === '') {
-    ctx.status = 400;
+router.get('/subject/:id', async (ctx) => {
+  const id = ctx.params.id;
+  const { update } = ctx.query;
+  try {
+    const { info, is_cache } = await getBookInfoById(id, update === '1');
+    ctx.body = {
+      success: true,
+      data: info,
+      is_cache,
+    };
+  } catch (err) {
+    ctx.response.status = 500;
     ctx.body = {
       success: false,
-      message: 'id or isbn is required.',
+      message: err,
     };
-  } else {
-    try {
-      const { info, is_cache } = id === ''
-        ? await getBookInfoByIsbn(isbn, update === '1')
-        : await getBookInfoById(id, update === '1');
-      ctx.body = {
-        success: true,
-        data: info,
-        is_cache,
-      };
-    } catch (err) {
-      ctx.response.status = 500;
-      ctx.body = {
-        success: false,
-        message: err,
-      };
-    }
+  }
+});
+
+router.get('/isbn/:isbn', async (ctx) => {
+  const isbn = ctx.params.isbn;
+  const { update } = ctx.query;
+  try {
+    const { info, is_cache } = await getBookInfoByIsbn(isbn, update === '1');
+    ctx.body = {
+      success: true,
+      data: info,
+      is_cache,
+    };
+  } catch (err) {
+    ctx.response.status = 500;
+    ctx.body = {
+      success: false,
+      message: err,
+    };
   }
 });
 


### PR DESCRIPTION
采用和豆瓣一致的URL。现在的URL采用的是`/book?id=<id>`或者`/book?isbn=<isbn>`的形式，这样在router里面就需要进行额外的判断。如果采用豆瓣的`/subject/<id>`或`/isbn/<isbn>`的形式，一方面简化了判断逻辑，另外方便用户检查页面的对应关系，只要把前面的网址换成豆瓣就能看到对应的页面。

此外，这样方便后续的接口设计，方便文档说明，比如系列查询只要用`/series/<id>`即可。